### PR TITLE
Now support late binding of runId 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.atscale.opensource</groupId>
   <artifactId>atscale-gatling-core</artifactId>
-  <version>1.17</version>
+  <version>1.18</version>
   <packaging>jar</packaging>
 
   <name>atscale_gatling</name>

--- a/src/main/com/atscale/java/executors/ConcurrentSimulationExecutor.java
+++ b/src/main/com/atscale/java/executors/ConcurrentSimulationExecutor.java
@@ -35,6 +35,10 @@ public abstract class ConcurrentSimulationExecutor<T> extends SimulationExecutor
                 LOGGER.info("Run Description: {}", task.getRunDescription());
 
                 try {
+                    if (task.isLateBindRunId()) {
+                        task.bindRunId();
+                    }
+
                     List<String> command = new java.util.ArrayList<>();
                     command.add(mavenScript);
 

--- a/src/main/com/atscale/java/executors/MavenTaskDto.java
+++ b/src/main/com/atscale/java/executors/MavenTaskDto.java
@@ -51,22 +51,28 @@ public class MavenTaskDto<T> {
     private String ingestionFileName;
     private boolean ingestionFileHasHeader;
     private boolean enhanceRunDescription;
+    private boolean lateBindRunId;
     @JsonSetter(nulls = Nulls.AS_EMPTY)
     private final Map<String, String> additionalProperties = new HashMap<>();
     private String alternatePropertiesFileName;
 
     public MavenTaskDto() {
-        // Delegate to the single-arg constructor so all initialization logic is reused
-        this("Default Task Name");
+        this("Default Task Name", false);
+    }
+
+    public MavenTaskDto(String taskName) {
+        this(taskName, false);
     }
 
     @JsonCreator
-    public MavenTaskDto(@JsonProperty("taskName") String taskName) {
+    public MavenTaskDto(@JsonProperty("taskName") String taskName, @JsonProperty("lateBindRunId") boolean lateBindRunId) {
         this.taskName = taskName;
-        // additionalProperties initialization moved to field declaration
-        String rid = generateRunId();
-        setRunId(rid);
-        setRunLogFileName(String.format("gatling-%s.log", rid));  //default value
+        this.lateBindRunId = lateBindRunId;
+        if (!lateBindRunId) {
+            String rid = generateRunId();
+            setRunId(rid);
+            setRunLogFileName(getLogFileNameForRunId(rid));
+        }
         setLoggingAsAppend(false);
     }
 
@@ -124,6 +130,14 @@ public class MavenTaskDto<T> {
         this.enhanceRunDescription = withRunId;
     }
 
+    public boolean isEnhanceRunDescription() {
+        return enhanceRunDescription;
+    }
+
+    public void setEnhanceRunDescription(boolean enhanceRunDescription) {
+        this.enhanceRunDescription = enhanceRunDescription;
+    }
+
     public String getCatalog() {return this.catalog;}
 
     @JsonIgnore
@@ -175,7 +189,11 @@ public class MavenTaskDto<T> {
         return encode(injectionStepsAsJson);
     }
 
-    private String generateRunId() {
+    public static String getLogFileNameForRunId(String runId) {
+        return String.format("gatling-%s.log", runId);
+    }
+
+    public static String generateRunId() {
         // Generate a timestamp-based run ID combined with a random alphanumeric string
         // This value is picked up in the logback.xml file where it is used to create a unique log file name
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
@@ -194,6 +212,18 @@ public class MavenTaskDto<T> {
     @JsonIgnore
     public String getRunIdBase64() {
         return encode(this.runId);
+    }
+
+    public boolean isLateBindRunId() {
+        return lateBindRunId;
+    }
+
+    public void bindRunId() {
+        String rid = generateRunId();
+        setRunId(rid);
+        if (StringUtils.isEmpty(logFileName)) {
+            setRunLogFileName(getLogFileNameForRunId(rid));
+        }
     }
 
     public void setRunLogFileName(String fileName) {

--- a/src/main/com/atscale/java/executors/SequentialSimulationExecutor.java
+++ b/src/main/com/atscale/java/executors/SequentialSimulationExecutor.java
@@ -34,6 +34,10 @@ public abstract class SequentialSimulationExecutor<T> extends SimulationExecutor
 
 
                 try {
+                    if (task.isLateBindRunId()) {
+                        task.bindRunId();
+                    }
+
                     List<String> command = new java.util.ArrayList<>();
                     command.add(mavenScript);
 

--- a/src/main/com/atscale/java/jdbc/JdbcProtocol.java
+++ b/src/main/com/atscale/java/jdbc/JdbcProtocol.java
@@ -39,6 +39,10 @@ public class JdbcProtocol {
         hikariConfig.setMaximumPoolSize(maxPool);
         hikariConfig.setConnectionInitSql(initSql);
         hikariConfig.setConnectionTestQuery("SELECT 1");
+        hikariConfig.setConnectionTimeout(PropertiesManager.getAtScaleJdbcConnectionTimeoutMs());
+        int socketTimeout = PropertiesManager.getAtScaleJdbcSocketTimeoutSeconds();
+        hikariConfig.addDataSourceProperty("socketTimeout", String.valueOf(socketTimeout));
+        hikariConfig.addDataSourceProperty("loginTimeout", String.valueOf(socketTimeout));
 
         return DB().hikariConfig(hikariConfig);
     }

--- a/src/main/com/atscale/java/utils/PropertiesManager.java
+++ b/src/main/com/atscale/java/utils/PropertiesManager.java
@@ -7,15 +7,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Properties;
 import java.util.List;
 import java.util.Arrays;
 import java.nio.file.Paths;
+import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class PropertiesManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesManager.class);
     private final Properties properties = new Properties();
+
+    // Package-private to allow test overrides without unsafe System class mocking
+    static Function<String, String> envReader = System::getenv;
     private final String propertiesFileName;
     private final String differentiator;
     private static final PropertiesManager instance = new PropertiesManager();
@@ -239,27 +244,15 @@ public class PropertiesManager {
     }
 
     public static String getAtScalePostgresURL() {
-        String property = instance.properties.getProperty("atscale.postgres.jdbc.url");
-        if (property == null || property.isEmpty()) {
-            throw new RuntimeException("atscale.postgres.jdbc.url is not set in properties file: " + instance.propertiesFileName);
-        }
-        return property;
+        return getProperty("atscale.postgres.jdbc.url");
     }
 
     public static String getAtScalePostgresUser() {
-        String property = instance.properties.getProperty("atscale.postgres.jdbc.username");
-        if (property == null || property.isEmpty()) {
-            throw new RuntimeException("atscale.postgres.jdbc.username is not set in properties file: " + instance.propertiesFileName);
-        }
-        return property;
+        return getProperty("atscale.postgres.jdbc.username");
     }
 
     public static String getAtScalePostgresPassword() {
-        String property = instance.properties.getProperty("atscale.postgres.jdbc.password");
-        if (property == null || property.isEmpty()) {
-            throw new RuntimeException("atscale.postgres.jdbc.password is not set in properties file: " + instance.propertiesFileName);
-        }
-        return property;
+        return getProperty("atscale.postgres.jdbc.password");
     }
 
     public static String getAtScaleJdbcConnection(String model) {
@@ -280,6 +273,14 @@ public class PropertiesManager {
     public static int getAtScaleJdbcMaxPoolSize(String model) {
         String key = String.format("atscale.%s.jdbc.maxPoolSize", clean(model));
         return Integer.parseInt(getProperty(key, "10"));
+    }
+
+    public static long getAtScaleJdbcConnectionTimeoutMs() {
+        return Long.parseLong(getProperty("atscale.jdbc.connectionTimeout.ms", "30000"));
+    }
+
+    public static int getAtScaleJdbcSocketTimeoutSeconds() {
+        return Integer.parseInt(getProperty("atscale.jdbc.socketTimeout.seconds", "60"));
     }
 
     public static boolean getRedactRawData(String model) {
@@ -331,10 +332,22 @@ public class PropertiesManager {
         return getProperty(key);
     }
 
+    public static boolean hasAtScaleXmlaAuthUserName(String model) {
+        String key = String.format("atscale.%s.xmla.auth.username", clean(model));
+        return hasProperty(key);
+    }
+
     public static String getAtScaleXmlaAuthPassword(String model) {
         String key = String.format("atscale.%s.xmla.auth.password", clean(model));
         return getProperty(key);
     }
+
+    public static boolean hasAtScaleXmlaAuthPassword(String model) {
+        String key = String.format("atscale.%s.xmla.auth.password", clean(model));
+        return hasProperty(key);
+    }
+
+
 
     public static void setCustomProperties(java.util.Map<String, String> customProperties) {
         for (String key : customProperties.keySet()) {
@@ -343,7 +356,14 @@ public class PropertiesManager {
         }
     }
 
+    // Package-private: for test cleanup only
+    static void removeProperties(Collection<String> keys) {
+        keys.forEach(instance.properties::remove);
+    }
+
     public static boolean hasProperty(String key) {
+        String envVal = envReader.apply(toEnvKey(key));
+        if (StringUtils.isNotEmpty(envVal)) return true;
         String property = instance.properties.getProperty(key);
         return StringUtils.isNotEmpty(property);
     }
@@ -353,6 +373,11 @@ public class PropertiesManager {
     }
 
     private static String getProperty(String key) {
+        String envVal = envReader.apply(toEnvKey(key));
+        if (envVal != null && !envVal.isEmpty()) {
+            LOGGER.info("Using environment variable override for property: {}", key);
+            return envVal;
+        }
         String property = instance.properties.getProperty(key);
         if (property == null || property.isEmpty()) {
             throw new RuntimeException("Property " + key + " is not set in properties file: " + instance.propertiesFileName);
@@ -362,10 +387,19 @@ public class PropertiesManager {
 
     @SuppressWarnings("all")
     private static String getProperty(String key, String defaultValue) {
-        if(! instance.properties.containsKey(key)) {
+        String envVal = envReader.apply(toEnvKey(key));
+        if (envVal != null && !envVal.isEmpty()) {
+            LOGGER.info("Using environment variable override for property: {}", key);
+            return envVal;
+        }
+        if (!instance.properties.containsKey(key)) {
             LOGGER.warn("Using default value for property {}: {}", key, defaultValue);
         }
         return instance.properties.getProperty(key, defaultValue);
+    }
+
+    private static String toEnvKey(String key) {
+        return key.replace(".", "_").replace("-", "_").toUpperCase();
     }
 
     private static String clean(String input) {

--- a/src/main/com/atscale/java/xmla/XmlaProtocol.java
+++ b/src/main/com/atscale/java/xmla/XmlaProtocol.java
@@ -23,12 +23,30 @@ public class XmlaProtocol {
         Integer maxConnections = PropertiesManager.getAtScaleXmlaMaxConnectionsPerHost();
 
         if (PropertiesManager.isContainerVersion(model)) {
-            LOGGER.info("Configured for container version.  Auth token is part of the URL.");
             LOGGER.info("Configured for max connections per host: {}", maxConnections);
-            return http.baseUrl(url)
+            boolean hasXmlaUser = PropertiesManager.hasAtScaleXmlaAuthUserName(model);
+            boolean hasXmlaPassword = PropertiesManager.hasAtScaleXmlaAuthPassword(model);
+
+            if (hasXmlaUser && hasXmlaPassword) {
+                LOGGER.info("Configured for container version with basic auth credentials.");
+                String username = PropertiesManager.getAtScaleXmlaAuthUserName(model);
+                String password = PropertiesManager.getAtScaleXmlaAuthPassword(model);
+                return http.baseUrl(url)
                     .contentTypeHeader("text/xml; charset=UTF-8")
                     .acceptHeader("text/xml")
+                    .authorizationHeader(getBasicAuthCredentials(username, password))
                     .maxConnectionsPerHost(maxConnections);
+            } else {
+                if (hasXmlaUser || hasXmlaPassword) {
+                    LOGGER.warn("Configured for container version: only one of xmla.auth.username / xmla.auth.password is set — basic auth requires both. Falling back to token-in-URL.");
+                } else {
+                    LOGGER.info("Configured for container version. Auth token is part of the URL.");
+                }
+                return http.baseUrl(url)
+                        .contentTypeHeader("text/xml; charset=UTF-8")
+                        .acceptHeader("text/xml")
+                        .maxConnectionsPerHost(maxConnections);
+            }
         } else {
             LOGGER.info("Configured for installer version.  Will obtain bearer auth token.");
             LOGGER.info("Configured for max connections per host: {}", maxConnections);
@@ -44,6 +62,11 @@ public class XmlaProtocol {
                     .authorizationHeader(bearerToken)
                     .maxConnectionsPerHost(maxConnections);
         }
+    }
+
+    public static String getBasicAuthCredentials(String username, String password) {
+        String auth = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String getBearerToken(String urlString, String username, String password) {

--- a/src/main/com/atscale/java/xmla/simulations/AtScaleXmlaSimulation.java
+++ b/src/main/com/atscale/java/xmla/simulations/AtScaleXmlaSimulation.java
@@ -5,6 +5,7 @@ import com.atscale.java.utils.JsonUtil;
 import com.atscale.java.utils.PropertiesManager;
 import com.atscale.java.xmla.scenarios.AtScaleXmlaScenario;
 import io.gatling.javaapi.core.ScenarioBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.gatling.javaapi.core.Simulation;

--- a/src/test/com/atscale/java/executors/MavenTaskDtoTest.java
+++ b/src/test/com/atscale/java/executors/MavenTaskDtoTest.java
@@ -105,4 +105,65 @@ public class MavenTaskDtoTest {
         assertNull(MavenTaskDto.encode(null));
         assertEquals("", MavenTaskDto.encode(""));
     }
+
+    @Test
+    public void testLateBindConstructorDoesNotGenerateRunId() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task", true);
+        assertNull(dto.getRunId());
+        assertNull(dto.getRunLogFileName());
+    }
+
+    @Test
+    public void testLateBindConstructorSetsFlagTrue() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task", true);
+        assertTrue(dto.isLateBindRunId());
+    }
+
+    @Test
+    public void testNormalConstructorSetsFlagFalse() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task");
+        assertFalse(dto.isLateBindRunId());
+    }
+
+    @Test
+    public void testNormalConstructorGeneratesRunId() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task");
+        assertNotNull(dto.getRunId());
+        assertFalse(dto.getRunId().isEmpty());
+    }
+
+    @Test
+    public void testBindRunIdGeneratesNonNullRunId() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task", true);
+        dto.bindRunId();
+        assertNotNull(dto.getRunId());
+        assertFalse(dto.getRunId().isEmpty());
+    }
+
+    @Test
+    public void testBindRunIdSetsLogFileName() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task", true);
+        dto.bindRunId();
+        assertNotNull(dto.getRunLogFileName());
+        assertTrue(dto.getRunLogFileName().startsWith("gatling-"));
+        assertTrue(dto.getRunLogFileName().endsWith(".log"));
+        assertTrue(dto.getRunLogFileName().contains(dto.getRunId()));
+    }
+
+    @Test
+    public void testBindRunIdPreservesExplicitLogFileName() {
+        MavenTaskDto<Object> dto = new MavenTaskDto<>("task", true);
+        dto.setRunLogFileName("internet_sales_xmla.log");
+        dto.bindRunId();
+        assertEquals("internet_sales_xmla.log", dto.getRunLogFileName());
+    }
+
+    @Test
+    public void testBindRunIdGeneratesUniqueIds() {
+        MavenTaskDto<Object> dto1 = new MavenTaskDto<>("task1", true);
+        MavenTaskDto<Object> dto2 = new MavenTaskDto<>("task2", true);
+        dto1.bindRunId();
+        dto2.bindRunId();
+        assertNotEquals(dto1.getRunId(), dto2.getRunId());
+    }
 }

--- a/src/test/com/atscale/java/utils/MavenTaskJsonUtilTest.java
+++ b/src/test/com/atscale/java/utils/MavenTaskJsonUtilTest.java
@@ -491,6 +491,36 @@ public class MavenTaskJsonUtilTest {
     }
 
 
+    @Test
+    public void testLateBindJsonRoundTripPreservesNoRunId() {
+        MavenTaskDto<OpenStep> dto = new MavenTaskDto<>("task", true);
+        dto.setMavenCommand("mvn test");
+        dto.setSimulationClass("com.example.TestSimulation");
+
+        String json = MavenTaskJsonUtil.openStepTasksToJson(List.of(dto));
+
+        List<MavenTaskDto<OpenStep>> loaded = MavenTaskJsonUtil.openStepTasksFromJson(json);
+        assertEquals(1, loaded.size());
+        assertTrue(loaded.get(0).isLateBindRunId());
+        assertNull(loaded.get(0).getRunId());
+        assertNull(loaded.get(0).getRunLogFileName());
+    }
+
+    @Test
+    public void testLateBindLoadAndBindProducesUniqueRunIds() {
+        MavenTaskDto<OpenStep> dto = new MavenTaskDto<>("task", true);
+        dto.setMavenCommand("mvn test");
+
+        String json = MavenTaskJsonUtil.openStepTasksToJson(List.of(dto));
+
+        MavenTaskDto<OpenStep> run1 = MavenTaskJsonUtil.openStepTasksFromJson(json).get(0);
+        MavenTaskDto<OpenStep> run2 = MavenTaskJsonUtil.openStepTasksFromJson(json).get(0);
+        run1.bindRunId();
+        run2.bindRunId();
+
+        assertNotEquals(run1.getRunId(), run2.getRunId());
+    }
+
     private boolean areEqual(List<? extends MavenTaskDto<?>> expected,
                              List<? extends MavenTaskDto<?>> actual) {
         if (expected.size() != actual.size()) {

--- a/src/test/com/atscale/java/utils/MavenTaskYamlUtilTest.java
+++ b/src/test/com/atscale/java/utils/MavenTaskYamlUtilTest.java
@@ -220,6 +220,36 @@ public class MavenTaskYamlUtilTest {
         MavenTaskYamlUtil.deleteTaskFile(fileName);
     }
 
+    @Test
+    public void testLateBindYamlRoundTripPreservesNoRunId() {
+        MavenTaskDto<OpenStep> dto = new MavenTaskDto<>("task", true);
+        dto.setMavenCommand("mvn test");
+        dto.setSimulationClass("com.example.TestSimulation");
+
+        String yaml = MavenTaskYamlUtil.openStepTasksToYaml(List.of(dto));
+
+        List<MavenTaskDto<OpenStep>> loaded = MavenTaskYamlUtil.openStepTasksFromYaml(yaml);
+        assertEquals(1, loaded.size());
+        assertTrue(loaded.get(0).isLateBindRunId());
+        assertNull(loaded.get(0).getRunId());
+        assertNull(loaded.get(0).getRunLogFileName());
+    }
+
+    @Test
+    public void testLateBindLoadAndBindProducesUniqueRunIds() {
+        MavenTaskDto<OpenStep> dto = new MavenTaskDto<>("task", true);
+        dto.setMavenCommand("mvn test");
+
+        String yaml = MavenTaskYamlUtil.openStepTasksToYaml(List.of(dto));
+
+        MavenTaskDto<OpenStep> run1 = MavenTaskYamlUtil.openStepTasksFromYaml(yaml).get(0);
+        MavenTaskDto<OpenStep> run2 = MavenTaskYamlUtil.openStepTasksFromYaml(yaml).get(0);
+        run1.bindRunId();
+        run2.bindRunId();
+
+        assertNotEquals(run1.getRunId(), run2.getRunId());
+    }
+
     private boolean areEqual(List<? extends MavenTaskDto<?>> expected,
                              List<? extends MavenTaskDto<?>> actual) {
         if (expected.size() != actual.size()) {

--- a/src/test/com/atscale/java/utils/PropertiesManagerTest.java
+++ b/src/test/com/atscale/java/utils/PropertiesManagerTest.java
@@ -4,38 +4,115 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class PropertiesManagerTest {
 
+    @AfterEach
+    void cleanup() {
+        PropertiesManager.envReader = System::getenv;
+        PropertiesManager.removeProperties(List.of(
+                "test.property", "another.property", "env.only.property", "has.property.test"
+        ));
+    }
+
+    // --- setCustomProperties / getCustomProperty ---
+
     @Test
-    public void testGetCustomProperty() {
-        Map<String, String> testProperties = Map.of("test.property", "testValue");
-        PropertiesManager.setCustomProperties(testProperties);
-        String value = PropertiesManager.getCustomProperty("test.property");
-        Assertions.assertEquals("testValue", value);
+    void testGetCustomProperty() {
+        PropertiesManager.setCustomProperties(Map.of("test.property", "testValue"));
+        Assertions.assertEquals("testValue", PropertiesManager.getCustomProperty("test.property"));
     }
 
     @Test
-    public void testGetCustomProperties() {
-        Map<String, String> testProperties = Map.of("test.property", "testValue", "another.property", "anotherValue");
-        PropertiesManager.setCustomProperties(testProperties);
-        String value = PropertiesManager.getCustomProperty("test.property");
-        Assertions.assertEquals("testValue", value);
-        String anotherValue = PropertiesManager.getCustomProperty("another.property");
-        Assertions.assertEquals("anotherValue", anotherValue);
+    void testGetCustomProperties() {
+        PropertiesManager.setCustomProperties(Map.of("test.property", "testValue", "another.property", "anotherValue"));
+        Assertions.assertEquals("testValue", PropertiesManager.getCustomProperty("test.property"));
+        Assertions.assertEquals("anotherValue", PropertiesManager.getCustomProperty("another.property"));
     }
 
     @Test
-    public void testCanSetEmptyMapWithoutError() {
-        Map<String, String> testProperties = Collections.emptyMap();
-        PropertiesManager.setCustomProperties(testProperties);
+    void testCanSetEmptyMapWithoutError() {
+        PropertiesManager.setCustomProperties(Collections.emptyMap());
     }
 
     @Test
-    public void testGettingNonExistentCustomPropertyThrowsError() {
+    void testGettingNonExistentCustomPropertyThrowsError() {
         Assertions.assertThrows(RuntimeException.class, () ->
                 PropertiesManager.getCustomProperty(RandomStringUtils.secure().nextAlphabetic(35))
         );
+    }
+
+    // --- env-var override: getProperty ---
+
+    @Test
+    void envVarOverridesPropertyFileValue() {
+        PropertiesManager.setCustomProperties(Map.of("test.property", "fromFile"));
+        PropertiesManager.envReader = key -> key.equals("TEST_PROPERTY") ? "fromEnv" : null;
+        Assertions.assertEquals("fromEnv", PropertiesManager.getCustomProperty("test.property"));
+    }
+
+    @Test
+    void envVarAloneResolvesPropertyWithoutFileEntry() {
+        PropertiesManager.envReader = key -> key.equals("ENV_ONLY_PROPERTY") ? "envOnly" : null;
+        Assertions.assertEquals("envOnly", PropertiesManager.getCustomProperty("env.only.property"));
+    }
+
+    @Test
+    void emptyEnvVarDoesNotOverridePropertyFileValue() {
+        PropertiesManager.setCustomProperties(Map.of("test.property", "fromFile"));
+        PropertiesManager.envReader = key -> "";
+        Assertions.assertEquals("fromFile", PropertiesManager.getCustomProperty("test.property"));
+    }
+
+    @Test
+    void nullEnvVarDoesNotOverridePropertyFileValue() {
+        PropertiesManager.setCustomProperties(Map.of("test.property", "fromFile"));
+        PropertiesManager.envReader = key -> null;
+        Assertions.assertEquals("fromFile", PropertiesManager.getCustomProperty("test.property"));
+    }
+
+    // --- env-var override: hasProperty ---
+
+    @Test
+    void hasPropertyReturnsTrueWhenKeyInFile() {
+        PropertiesManager.setCustomProperties(Map.of("has.property.test", "value"));
+        Assertions.assertTrue(PropertiesManager.hasProperty("has.property.test"));
+    }
+
+    @Test
+    void hasPropertyReturnsFalseWhenKeyAbsent() {
+        Assertions.assertFalse(PropertiesManager.hasProperty(RandomStringUtils.secure().nextAlphabetic(35)));
+    }
+
+    @Test
+    void hasPropertyReturnsTrueWhenEnvVarSetButNotInFile() {
+        PropertiesManager.envReader = key -> key.equals("ENV_ONLY_PROPERTY") ? "envOnly" : null;
+        Assertions.assertTrue(PropertiesManager.hasProperty("env.only.property"));
+    }
+
+    @Test
+    void hasPropertyReturnsFalseWhenEnvVarIsEmpty() {
+        PropertiesManager.envReader = key -> "";
+        Assertions.assertFalse(PropertiesManager.hasProperty(RandomStringUtils.secure().nextAlphabetic(35)));
+    }
+
+    // --- toEnvKey mapping ---
+
+    @Test
+    void dotsConvertedToUnderscoresAndUppercasedInEnvLookup() {
+        // key "a.b.c" should look up env var "A_B_C"
+        PropertiesManager.envReader = key -> key.equals("A_B_C") ? "mapped" : null;
+        PropertiesManager.setCustomProperties(Map.of("a.b.c", "fromFile"));
+        Assertions.assertEquals("mapped", PropertiesManager.getCustomProperty("a.b.c"));
+    }
+
+    @Test
+    void hyphensConvertedToUnderscoresInEnvLookup() {
+        // key "a-b-c" should look up env var "A_B_C"
+        PropertiesManager.envReader = key -> key.equals("A_B_C") ? "mapped" : null;
+        PropertiesManager.setCustomProperties(Map.of("a-b-c", "fromFile"));
+        Assertions.assertEquals("mapped", PropertiesManager.getCustomProperty("a-b-c"));
     }
 }


### PR DESCRIPTION
Late binding means we are able to reuse MavenTaskDto objects that have been serialized to yaml or json without regenerating the yaml to have a unique runID per run.

Also riding along are changes to the auth handling for XMLA endpoint needed for Snowflake OEM project.    That code is not yet working and tested.  However it does no harm so letting it get a free ride ahead of schedule.

Need this code to be released to Maven Central so that we can get the late binding changes, version 1.18, which unblocks testing GitHub actions for the qa-perf env.