### PR TITLE
alternate properties file use in sequential executors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.atscale.opensource</groupId>
   <artifactId>atscale-gatling-core</artifactId>
-  <version>1.18</version>
+  <version>1.19</version>
   <packaging>jar</packaging>
 
   <name>atscale_gatling</name>

--- a/src/main/com/atscale/java/executors/ConcurrentSimulationExecutor.java
+++ b/src/main/com/atscale/java/executors/ConcurrentSimulationExecutor.java
@@ -25,8 +25,11 @@ public abstract class ConcurrentSimulationExecutor<T> extends SimulationExecutor
         List<Thread> taskThreads = new java.util.ArrayList<>();
         List<MavenTaskDto<T>> tasks = getSimulationTasks();
 
+        int taskIndex = 0;
         for (MavenTaskDto<T> task : tasks) {
+                final int startDelaySeconds = taskIndex++ * 3;
                 Thread taskThread = new Thread(() -> {
+                try { Thread.sleep(startDelaySeconds * 1000L); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
                 String osName = System.getProperty("os.name").toLowerCase();
                 LOGGER.info("OS is {}", osName);
                 LOGGER.info("Running task: {}", task.getTaskName());

--- a/src/main/com/atscale/java/executors/SequentialSimulationExecutor.java
+++ b/src/main/com/atscale/java/executors/SequentialSimulationExecutor.java
@@ -54,9 +54,6 @@ public abstract class SequentialSimulationExecutor<T> extends SimulationExecutor
                     String ingestFileHasHeader = String.format("-D%s=%s", MavenTaskDto.ATSCALE_QUERY_INGESTION_FILE_HAS_HEADER, task.getIngestionFileHasHeader());
                     String additionalProperties = String.format("-D%s=%s", MavenTaskDto.ADDITIONAL_PROPERTIES, task.getAdditionalPropertiesBase64());
                     String alternatePropertiesFileName = task.getAlternatePropertiesFileName();
-                    if(StringUtils.isNotEmpty(alternatePropertiesFileName)){
-                        throw new UnsupportedOperationException("Sequential executors do not support the use of alternate properties files.  Remove the call(s) to setAlternatePropertiesFileName() in the task definition(s).");
-                    }
 
                     LOGGER.debug("SimEx Using simulation class: {}", simClass);
                     LOGGER.debug("SimEx Using run description: {}", runDesc);
@@ -69,6 +66,7 @@ public abstract class SequentialSimulationExecutor<T> extends SimulationExecutor
                     LOGGER.debug("SimEx Using ingestion file: {}", ingestFile);
                     LOGGER.debug("SimEx Ingestion file has header: {}", ingestFileHasHeader);
                     LOGGER.debug("SimEx Using additional properties: {}", additionalProperties);
+                    LOGGER.debug("SimEx Using alternate properties file name: {}", alternatePropertiesFileName);
 
                     command.add(simClass);
                     command.add(runDesc);
@@ -81,6 +79,9 @@ public abstract class SequentialSimulationExecutor<T> extends SimulationExecutor
                     command.add(ingestFile);
                     command.add(ingestFileHasHeader);
                     command.add(additionalProperties);
+                    if (StringUtils.isNotEmpty(alternatePropertiesFileName)) {
+                        command.add(String.format("-D%s=%s", "systems.properties.file", alternatePropertiesFileName));
+                    }
 
                     // Add the Maven goal (e.g., gatling:test)
                     command.add(task.getMavenCommand());


### PR DESCRIPTION
Now support alternate properties file use in sequential executors.  Also added a small delay when starting multiple concurrent executors in order to lessen resource contention which could be an intermittent failure issue on localhost.